### PR TITLE
added closed as an option for detection status

### DIFF
--- a/config/config.js
+++ b/config/config.js
@@ -226,6 +226,10 @@ module.exports = {
         {
           value: 'new',
           display: 'New'
+        },
+        {
+          value: 'closed',
+          display: 'Closed'
         }
       ],
       multiple: true,

--- a/config/config.json
+++ b/config/config.json
@@ -156,6 +156,10 @@
         {
           "value": "new",
           "display": "New"
+        },
+        {
+          "value": "closed",
+          "display": "Closed"
         }
       ],
       "multiple": true,


### PR DESCRIPTION
Added `closed` as an option for `detectionStatuses`. This may only be necessary/valid for Falcon Complete or organizations that move detections to `closed` (vs. use of `true_positive` and `false_positive`).